### PR TITLE
Install project requirements for CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install torch --index-url https://download.pytorch.org/whl/cpu
-          pip install numpy pandas scikit-learn
+          pip install -r requirements.txt --extra-index-url https://download.pytorch.org/whl/cpu
           pip install -r requirements-dev.txt
 
       - name: Ruff (tests only)


### PR DESCRIPTION
## Summary
- install the primary project dependencies from requirements.txt before running linting and pytest in CI

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f51a9662d4832f86e7d09b032d1d49